### PR TITLE
Normalize README formatting and add editor configs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+# Node
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+.env
+.venv/
+env/
+venv/
+build/
+dist/
+.eggs/
+*.egg-info/
+pip-wheel-metadata/
+.mypy_cache/
+.pytest_cache/
+.ipynb_checkpoints
+.coverage
+*.cover
+htmlcov/
+.cache/
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+
+# VSCode
+.vscode/
+.history/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # maru
 
 ## Setup
+
 - init check


### PR DESCRIPTION
## Summary
- add proper spacing to the README setup section for valid markdown rendering
- introduce a comprehensive .gitignore covering Node, Python, macOS, and VS Code artifacts
- add a root .editorconfig to enforce consistent formatting defaults

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cad1b722fc8321b4ad7b88aadc51f8